### PR TITLE
[WORK IN PROGRESS / NOT READY] Ajout d'une seconde source pour la mesure Triac (Source_T)

### DIFF
--- a/EnvoiMQTT.ino
+++ b/EnvoiMQTT.ino
@@ -24,7 +24,7 @@ void GestionMQTT() {
       if (Source_Temp[C] == "tempMqtt")
         Temper = true;
     }
-    if (MQTTRepet > 0 || Temper || Source == "Pmqtt" || subMQTT == 1) {
+    if (MQTTRepet > 0 || Temper || Source == "Pmqtt" || Source_T == "Pmqtt" || subMQTT == 1) {
       if (testMQTTconnected()) {
         clientMQTT.loop();
         envoiVersMQTT();
@@ -65,6 +65,12 @@ bool testMQTTconnected() {
         char Topicp[50];
         snprintf(Topicp, sizeof(Topicp), "%s", TopicP.c_str());
         clientMQTT.subscribe(Topicp);
+      }
+      // Souscription au topic dédié si Pmqtt est utilisée comme Source_T (canal Triac)
+      if (Source_T == "Pmqtt" && TopicP_T.length() > 0) {
+        char Topicpt[50];
+        snprintf(Topicpt, sizeof(Topicpt), "%s", TopicP_T.c_str());
+        clientMQTT.subscribe(Topicpt);
       }
       if (subMQTT == 1) {
         char TopicAct[60];
@@ -129,13 +135,21 @@ void callback(char *topic, byte *payload, unsigned int length) {
     }
   }
 
-  if (String(topic) == TopicP && Source == "Pmqtt") {  // Mesure de puissance
+  if (String(topic) == TopicP && Source == "Pmqtt") {  // Mesure de puissance canal M
     PwMQTT = ValJson("Pw", message);
     PvaMQTT = ValJson("Pva", message);
     PfMQTT = ValJson("Pf", message);
     P_MQTT_Brute = String(Message);
     if (message.indexOf("Pw") > 0)
       LastPwMQTTMillis = millis();
+  }
+  if (String(topic) == TopicP_T && Source_T == "Pmqtt") {  // Mesure de puissance canal T (Triac)
+    PwMQTT_T = ValJson("Pw", message);
+    PvaMQTT_T = ValJson("Pva", message);
+    PfMQTT_T = ValJson("Pf", message);
+    P_MQTT_Brute_T = String(Message);
+    if (message.indexOf("Pw") > 0)
+      LastPwMQTTMillis_T = millis();
   }
   if (subMQTT == 1) {
     char TopicAct[60];
@@ -195,7 +209,9 @@ void sendMQTTDiscoveryMsg_global() {
   String ActionOnOff;
   // augmente la taille du buffer wifi Mqtt (voir PubSubClient.h)
   clientMQTT.setBufferSize(1700);  // voir -->#define MQTT_MAX_PACKET_SIZE 256 is the default value in PubSubClient.h
-  if (Source == "UxIx2" || Source == "ShellyEm" || Source == "ShellyPro") {
+  // Découverte des capteurs Triac (T) : alimentés si Source_T est configurée
+  // ou si la source M est multi-mesures (UxIx2 / ShellyEm / ShellyProEm en mode 2-voies — remplit _T via sa voie secondaire)
+  if (Source_T != "NotDef" || Source == "UxIx2" || Source == "ShellyEm" || Source == "ShellyPro") {
     DeviceToDiscover("PuissanceS_T", "Puissance T Soutirée", "W", "power", "0");
     DeviceToDiscover("PuissanceI_T", "Puissance T Injectée", "W", "power", "0");
     DeviceToDiscover("Tension_T", "Tension T", "V", "voltage", "2");
@@ -373,8 +389,13 @@ void SendDataToHomeAssistant() {
   // On garde trace de la position
   int len = snprintf(value, sizeof(value), "{\"PuissanceS_M\": %d, \"PuissanceI_M\": %d, \"Tension_M\": %.1f, \"Intensite_M\": %.1f, \"PowerFactor_M\": %.2f, \"Energie_M_Soutiree\":%ld,\"Energie_M_Injectee\":%ld, \"EnergieJour_M_Soutiree\":%ld, \"EnergieJour_M_Injectee\":%ld", PuissanceS_M, PuissanceI_M, Tension_M, Intensite_M, PowerFactor_M, Energie_M_Soutiree, Energie_M_Injectee, EnergieJour_M_Soutiree, EnergieJour_M_Injectee);
 
-  if (Source == "UxIx2" || Source == "ShellyEm" || Source == "ShellyPro") {
+  // Publication des mesures Triac (T) : alimentées si Source_T est configurée
+  // ou si la source M est multi-mesures (UxIx2 / ShellyEm / ShellyProEm en mode 2-voies — remplit _T via sa voie secondaire)
+  if (Source_T != "NotDef" || Source == "UxIx2" || Source == "ShellyEm" || Source == "ShellyPro") {
     len += snprintf(value + len, sizeof(value) - len, ",\"PuissanceS_T\": %d, \"PuissanceI_T\": %d, \"Tension_T\": %.1f, \"Intensite_T\": %.1f, \"PowerFactor_T\": %.2f, \"Energie_T_Soutiree\":%ld,\"Energie_T_Injectee\":%ld, \"EnergieJour_T_Soutiree\":%ld, \"EnergieJour_T_Injectee\":%ld, \"Frequence\":%.2f", PuissanceS_T, PuissanceI_T, Tension_T, Intensite_T, PowerFactor_T, Energie_T_Soutiree, Energie_T_Injectee, EnergieJour_T_Soutiree, EnergieJour_T_Injectee, Frequence);
+    if (Source_T != "NotDef") {  // Identifie la source T dans le payload MQTT
+      len += snprintf(value + len, sizeof(value) - len, ",\"Source_T\":\"%s\"", Source_T.c_str());
+    }
   }
   for (int canal = 0; canal < 4; canal++) {
     if (temperature[canal] > -100 && Source_Temp[canal] != "tempNo") {

--- a/JS_Para.h
+++ b/JS_Para.h
@@ -108,6 +108,8 @@ function SetParaFixe() {
     // Autres paramètres
     GID("ModeW").value = F.ModeReseau;
     GID("sources").value = F.Source;
+    GID("sources_T").value = F.Source_T || "NotDef";  // Source du canal T (Triac)
+    GID("TopicP_T").value = F.TopicP_T || "";          // Topic MQTT pour Source_T = Pmqtt
     GID("RMSextIP").value = int2ip(F.RMSextIP);
     GID("RMSextIPauto").checked = F.RMSextIPauto == 1;
     GID("EnphaseUser").value = F.EnphaseUser;
@@ -190,7 +192,9 @@ function SendValues() {
   F.pUxI = GID("pUxI").value;
   F.pTemp = GID("PTemp").value;
   F.ReacCACSI = GID("EstimCACSI").checked ? 100 : 0; 
-  F.Source=GID("sources").value;
+  F.Source = GID("sources").value;
+  F.Source_T = GID("sources_T").value;     // Source du canal T (Triac)
+  F.TopicP_T = GID("TopicP_T").value.trim(); // Topic MQTT pour Source_T = Pmqtt
   if (F.ModePara == 0) { //Non Expert
     F.subMQTT = 0; F.WifiSleep = 1;
   }
@@ -408,7 +412,16 @@ function checkDisabled() {
     
     // Visibilité du Topic de Puissance (pour source 11/MQTT)
     GID('ligneTopicP').style.display = (GID("sources").value == "Pmqtt") ? "table-row" : "none";
-    
+
+    // Visibilité du topic Pmqtt côté T : uniquement si Source_T == Pmqtt
+    GID('ligneTopicP_T').style.display = (GID("sources_T").value == "Pmqtt") ? "table-row" : "none";
+    // Avertissement si Source_T == Source (cas ignoré par le firmware sauf pour les sources multi-mesures)
+    const sourcesMultiMesures = ["UxIx2", "ShellyEm", "ShellyPro"];
+    const sameSrc = GID("sources_T").value === GID("sources").value
+                    && GID("sources_T").value !== "NotDef"
+                    && !sourcesMultiMesures.includes(GID("sources").value);
+    GID('ligneSource_T_Warn').style.display = sameSrc ? "table-row" : "none";
+
     // Mise à jour et appel final
     F.Source = GID("sources").value;
     if (F.Source != 'Ext') V.Source_data = F.Source;
@@ -448,8 +461,10 @@ function checkIP(id) {
  * Adapte l'affichage des champs de source de données en fonction de la source sélectionnée.
  */
 function AdaptationSource() {
-    // Visibilité des options de nom (Fixe)
-    const isSourceDual = (V.Source_data === 'UxIx2' || ((V.Source_data === 'ShellyEm' || V.Source_data === 'ShellyPro') && GID("EnphaseSerial").value != 3));
+    // Visibilité des options de nom (Fixe) : source multi-mesures en Source OU Source_T configurée
+    const hasSourceT = (GID("sources_T").value !== "NotDef");
+    const isSourceDual = hasSourceT ||
+        (V.Source_data === 'UxIx2' || ((V.Source_data === 'ShellyEm' || V.Source_data === 'ShellyPro') && GID("EnphaseSerial").value != 3));
     GID('ligneFixe').style.display = isSourceDual ? "table-row" : "none";
     GID('ligneFixe1').style.display = isSourceDual ? "table-row" : "none";
     GID('ligneFixe2').style.display = isSourceDual ? "table-row" : "none";

--- a/PagePara.h
+++ b/PagePara.h
@@ -343,9 +343,9 @@ const char *ParaHtml = R"====(
       <div class="form">
 
         <div class="ligne">
-          <label for="sources">Source</label>
+          <label for="sources">Source Maison (M) <span class="fsize10">— pilote le routeur</span></label>
           <select id="sources" onclick="checkDisabled();"
-                  title="Suivant l'interface de mesure choisie.">
+                  title="Source mesurant la puissance à l'entrée Maison. Pilote le routage.">
             <option value="NotDef" selected>Non définie</option>
             <option value="UxI">UxI</option>
             <option value="UxIx2">UxIx2</option>
@@ -396,6 +396,27 @@ const char *ParaHtml = R"====(
         <div class="ligne" id="ligneTopicP">
           <label for="TopicP">MQTT Topic Puissance :</label>
           <input type="text" id="TopicP" name="TopicP" autocomplete="on">
+        </div>
+
+        <div class="ligne">
+          <label for="sources_T">Source Triac (T) <span class="fsize10">— mesure de la sortie Triac</span></label>
+          <select id="sources_T" onclick="checkDisabled();"
+                  title="Source mesurant la puissance délivrée par la sortie Triac. Optionnelle. Note : avec UxIx3, les tensions/courants par phase apparaîtront sous Tension_M1/M2/M3 (préfixe historique conservé).">
+            <option value="NotDef" selected>Aucune</option>
+            <option value="UxI">UxI</option>
+            <option value="UxIx2">UxIx2 (voie 1 du JSY)</option>
+            <option value="UxIx3">UxIx3 (Triac mono ou triphasé)</option>
+            <option value="ShellyEm">Shelly Em</option>
+            <option value="ShellyPro">Shelly Pro Em</option>
+            <option value="Pmqtt">MQTT (topic distinct)</option>
+          </select>
+        </div>
+        <div class="ligne" id="ligneTopicP_T" style="display:none;">
+          <label for="TopicP_T">MQTT Topic Puissance Triac :</label>
+          <input type="text" id="TopicP_T" name="TopicP_T" autocomplete="on">
+        </div>
+        <div class="ligne" id="ligneSource_T_Warn" style="display:none;color:#c00;">
+          <span class="fsize10">⚠ La source Triac doit être différente de la source Maison.</span>
         </div>
 
         <div><span class="fsize10">Nécessite un Restart de l'ESP32</span></div>

--- a/Solar_Router_V17_19.ino
+++ b/Solar_Router_V17_19.ino
@@ -403,8 +403,9 @@ String ssid = "";
 String password = "";
 String CleAcces = "";
 String CleAccesRef = "";
-String Source = "NotDef";
-String Source_data = "NotDef";
+String Source = "NotDef";      // Source de mesure du canal M (Maison) — pilote le routeur
+String Source_data = "NotDef"; // Source réelle quand Source == "Ext" (chaînage d'ESP32)
+String Source_T = "NotDef";    // Source de mesure du canal T (Triac) — "NotDef" = pas de mesure dédiée
 String SerialIn = "";
 String hostname = "";
 byte dhcpOn = 1;
@@ -433,7 +434,8 @@ String MQTTPwd = "password";
 String MQTTPrefix = "homeassistant";  // prefix obligatoire pour l'auto-discovery entre HA et Core-Mosquitto (par défaut c'est homeassistant)
 String MQTTPrefixEtat = "homeassistant";
 String MQTTdeviceName = "routeur_rms";
-String TopicP = "PuissanceMaison";
+String TopicP = "PuissanceMaison";    // Topic MQTT pour la source du canal M (Pmqtt)
+String TopicP_T = "PuissanceTriac";   // Topic MQTT pour la source du canal T (Pmqtt en source T)
 byte subMQTT = 0;
 String nomRouteur = "Routeur - RMS";
 String nomSondeMobile = "Données Maison";
@@ -523,8 +525,39 @@ float Puissance_T_moy, Puissance_M_moy;
 float PVA_T_moy, PVA_M_moy;
 
 // PhDV61   float ne suffit pas lorsque la valeur totale devient très grande, et les incréments très petits (pendant le routage par exemple)
-double EASfloat = 0;
-double EAIfloat = 0;
+double EASfloat = 0;          // Accumulateur Wh soutirée pour le canal M (UxI, MQTT)
+double EAIfloat = 0;          // Accumulateur Wh injectée pour le canal M
+double EASfloat_T = 0;        // Accumulateur Wh soutirée pour le canal T (idem si UxI/MQTT en Source_T)
+double EAIfloat_T = 0;        // Accumulateur Wh injectée pour le canal T
+double Energie_M_Soutiree_double = 0.0;  // Compteur double précision pour la mesure Maison (UxIx3)
+double Energie_M_Injectee_double = 0.0;
+double Energie_T_Soutiree_double = 0.0;  // Compteur double précision pour la mesure Triac (UxIx3)
+double Energie_T_Injectee_double = 0.0;
+
+// Canal de lecture courant : 'M' (Maison) ou 'T' (Triac). Mis à jour par Set_Canal_Lecture()
+// avant chaque appel à Lecture_Source(). Lu par les sources multi-mesures pour décider de la voie 2.
+char canal_lecture_courant = 'M';
+
+// Pointeurs indirects vers les variables du canal courant. Initialisés sur le canal M
+// dès la déclaration (valides au boot avant tout appel) puis repositionnés par
+// Set_Canal_Lecture('M'/'T') selon le contexte de chaque lecture de source.
+float*  pPuissanceS_inst        = &PuissanceS_M_inst;
+float*  pPuissanceI_inst        = &PuissanceI_M_inst;
+float*  pPVAS_inst              = &PVAS_M_inst;
+float*  pPVAI_inst              = &PVAI_M_inst;
+float*  pTension                = &Tension_M;
+float*  pIntensite              = &Intensite_M;
+float*  pPowerFactor            = &PowerFactor_M;
+long*   pEnergie_Soutiree       = &Energie_M_Soutiree;
+long*   pEnergie_Injectee       = &Energie_M_Injectee;
+long*   pEnergieJour_Soutiree   = &EnergieJour_M_Soutiree;
+long*   pEnergieJour_Injectee   = &EnergieJour_M_Injectee;
+double* pEASfloat               = &EASfloat;
+double* pEAIfloat               = &EAIfloat;
+double* pEnergie_Soutiree_double = &Energie_M_Soutiree_double;
+double* pEnergie_Injectee_double = &Energie_M_Injectee_double;
+float*  pPuissance_moy          = &Puissance_M_moy;
+float*  pPVA_moy                = &PVA_M_moy;
 
 int PactConso_M, PactProd;
 int16_t tabPw_Maison_5mn[600];  //Puissance Active:Soutiré-Injecté toutes les 5mn
@@ -601,8 +634,6 @@ float  Energie_Minuit_JSY_Soutiree = 0.0;  // Le contenu sera initialisé au pre
 float  Energie_Minuit_JSY_Injectee = 0.0;  // Le contenu sera initialisé au premier appel UxIx3 après Reset
 float  Energie_Jour_JSY_Soutiree   = 0.0;  // Le contenu sera initialisé au premier appel UxIx3 après Reset
 float  Energie_Jour_JSY_Injectee   = 0.0;  // Le contenu sera initialisé au premier appel UxIx3 après Reset
-double Energie_M_Soutiree_double    = 0.0;
-double Energie_M_Injectee_double    = 0.0;
 
 long Temps_precedent = 0;  // mesure précise du temps entre deux appels au JSY-MK-333
 float PW_M1, PW_M2, PW_M3;
@@ -670,6 +701,11 @@ String P_MQTT_Brute = "";
 float PwMQTT = 0;
 float PvaMQTT = 0;
 float PfMQTT = 1;
+// Valeurs en cache pour Pmqtt utilisé comme Source_T (topic distinct = TopicP_T)
+String P_MQTT_Brute_T = "";
+float PwMQTT_T = 0;
+float PvaMQTT_T = 0;
+float PfMQTT_T = 1;
 
 //Paramètres pour RTE
 byte TempoRTEon = 0;
@@ -714,6 +750,7 @@ float previousTimeRMSMoy = 0;
 unsigned long previousMQTTenvoiMillis;
 unsigned long previousMQTTMillis;
 unsigned long LastPwMQTTMillis = 0;
+unsigned long LastPwMQTTMillis_T = 0;  // Horodatage de dernière réception sur TopicP_T
 unsigned long PeriodeMQTTMillis = 500;
 unsigned long LastShowActionMillis = 0;
 
@@ -960,6 +997,97 @@ void WiFiEvent(WiFiEvent_t event) {  //SR19
   }                           //SR19
 }
 
+
+// ---------------------------------------------------------
+// Fonctions génériques de dispatch des sources de mesure
+// ---------------------------------------------------------
+
+// Initialise le module correspondant à la source donnée (primaire ou secondaire)
+void Setup_Source(String src) {
+  if (src == "UxI")    Setup_UxI();
+  if (src == "Enphase") Setup_Enphase();
+  if (pSerial > 0) {
+    if (src == "UxIx2") Setup_UxIx2();
+    if (src == "Linky")  Setup_Linky();
+  }
+}
+
+// Appelle la lecture de la source indiquée et ajuste PeriodeProgMillis.
+// Le paramètre canal ('M' ou 'T') détermine vers quel jeu de variables la source écrit.
+// PeriodeProgMillis est ajustée uniquement pour le canal 'M' (la cadence est pilotée par la source Maison).
+void Lecture_Source(String src, char canal) {
+  Set_Canal_Lecture(canal);
+
+  unsigned long ralenti = long(PuissanceS_M / 10);  // Ralentit le polling si forte puissance soutirée
+  unsigned long periode = PeriodeProgMillis;        // On modifiera periode dans tous les cas, mais on
+                                                    // ne la propage à PeriodeProgMillis qu'en canal 'M'.
+  bool updateLastRMS = false;
+
+  if (src == "NotDef")  { LectureNotDef();        periode = 600; }
+  if (src == "UxI")     { LectureUxI();           periode = 40; }
+  if (pSerial > 0) {
+    if (src == "UxIx2") { LectureUxIx2();         periode = 400; }
+    if (src == "UxIx3") { Lecture_JSY333();        periode = (Serial2V == 19200) ? 500 : 800; }
+    if (src == "Linky") { LectureLinky();          periode = 2; }
+  }
+  if (src == "Enphase")  { LectureEnphase();       updateLastRMS = true; periode = 600 + ralenti; }
+  if (src == "SmartG")   { LectureSmartG();        updateLastRMS = true; periode = 300 + ralenti; }
+  if (src == "HomeW")    { LectureHomeW();         updateLastRMS = true; periode = 300 + ralenti; }
+  if (src == "ShellyEm") { LectureShellyEm();     updateLastRMS = true; periode = 300 + ralenti; }
+  if (src == "ShellyPro"){ LectureShellyProEm();  updateLastRMS = true; periode = 300 + ralenti; }
+  if (src == "Ext")      { CallESP32_Externe();    updateLastRMS = true; periode = 800 + ralenti; }
+  if (src == "Pmqtt")    { UpdatePmqtt();          updateLastRMS = true; periode = 600; }
+
+  if (canal == 'M') {
+    PeriodeProgMillis = periode;                   // La cadence du loop est pilotée par la source M
+    if (updateLastRMS) LastRMS_Millis = millis();
+  }
+}
+
+// Bascule les pointeurs canal vers les variables _M ou _T.
+// Doit être appelé AVANT chaque exécution d'une source de mesure.
+// Les sources qui écrivent uniquement dans _M (UxI, Linky, etc.) le font via ces pointeurs et alimentent
+// donc le bon canal sans connaître elles-mêmes le contexte.
+void Set_Canal_Lecture(char canal) {
+  canal_lecture_courant = canal;
+  if (canal == 'T') {
+    pPuissanceS_inst        = &PuissanceS_T_inst;
+    pPuissanceI_inst        = &PuissanceI_T_inst;
+    pPVAS_inst              = &PVAS_T_inst;
+    pPVAI_inst              = &PVAI_T_inst;
+    pTension                = &Tension_T;
+    pIntensite              = &Intensite_T;
+    pPowerFactor            = &PowerFactor_T;
+    pEnergie_Soutiree       = &Energie_T_Soutiree;
+    pEnergie_Injectee       = &Energie_T_Injectee;
+    pEnergieJour_Soutiree   = &EnergieJour_T_Soutiree;
+    pEnergieJour_Injectee   = &EnergieJour_T_Injectee;
+    pEASfloat               = &EASfloat_T;
+    pEAIfloat               = &EAIfloat_T;
+    pEnergie_Soutiree_double = &Energie_T_Soutiree_double;
+    pEnergie_Injectee_double = &Energie_T_Injectee_double;
+    pPuissance_moy          = &Puissance_T_moy;
+    pPVA_moy                = &PVA_T_moy;
+  } else {  // canal 'M' (par défaut)
+    pPuissanceS_inst        = &PuissanceS_M_inst;
+    pPuissanceI_inst        = &PuissanceI_M_inst;
+    pPVAS_inst              = &PVAS_M_inst;
+    pPVAI_inst              = &PVAI_M_inst;
+    pTension                = &Tension_M;
+    pIntensite              = &Intensite_M;
+    pPowerFactor            = &PowerFactor_M;
+    pEnergie_Soutiree       = &Energie_M_Soutiree;
+    pEnergie_Injectee       = &Energie_M_Injectee;
+    pEnergieJour_Soutiree   = &EnergieJour_M_Soutiree;
+    pEnergieJour_Injectee   = &EnergieJour_M_Injectee;
+    pEASfloat               = &EASfloat;
+    pEAIfloat               = &EAIfloat;
+    pEnergie_Soutiree_double = &Energie_M_Soutiree_double;
+    pEnergie_Injectee_double = &Energie_M_Injectee_double;
+    pPuissance_moy          = &Puissance_M_moy;
+    pPVA_moy                = &PVA_M_moy;
+  }
+}
 
 // SETUP
 //*******
@@ -1260,38 +1388,19 @@ void setup() {
   ArduinoOTA.setHostname((const char *)hostname.c_str());
   ArduinoOTA.begin();  //Mandatory
 
-  //Adaptation à la Source
-  TelnetPrintln("Source : " + Source);
+  // Initialisation du canal M (Maison) — pilote le routage
+  Set_Canal_Lecture('M');                         // Positionne les pointeurs sur les variables _M
+  TelnetPrintln("Source (M) : " + Source);
+  Setup_Source(Source);
+  if (Source == "Pmqtt" || Source_T == "Pmqtt") GestionMQTT();  // Souscription MQTT si nécessaire
+  if (Source == "Ext") { IndexSource(); } else { Source_data = Source; }
 
-  if (Source == "UxI") {
-    Setup_UxI();
-  }
-
-  if (Source == "Enphase") {
-    Setup_Enphase();
-  }
-
-
-  if (Source == "Pmqtt") {
-    GestionMQTT();
-  }
-
-  //Port Série si besoin
-  if (pSerial > 0) {
-
-    if (Source == "UxIx2") {
-      Setup_UxIx2();
-    }
-
-    if (Source == "Linky") {
-      Setup_Linky();
-    }
-  }
-
-  if (Source == "Ext") {
-    IndexSource();
-  } else {
-    Source_data = Source;
+  // Initialisation du canal T (Triac) — optionnel
+  if (Source_T != "NotDef" && Source_T != Source) {
+    TelnetPrintln("Source_T : " + Source_T);
+    Set_Canal_Lecture('T');                       // Pour que Setup_Source pointe sur les variables _T si besoin
+    Setup_Source(Source_T);
+    Set_Canal_Lecture('M');                       // On laisse les pointeurs sur M par défaut
   }
   LireSerial();
 
@@ -1373,65 +1482,13 @@ void Task_LectureRMS(void *pvParameters) {
     //******************************
     if (tps - LastRMS_Millis > PeriodeProgMillis) {  //Attention delicat pour eviter pb overflow
       LastRMS_Millis = tps;
-      unsigned long ralenti = long(PuissanceS_M / 10);  // On peut ralentir échange sur Wifi si grosse puissance soutirée en cours
-      if (Source == "NotDef") {
-        LectureNotDef();
-        PeriodeProgMillis = 600;
-      }
-      if (Source == "UxI") {
-        LectureUxI();
-        PeriodeProgMillis = 40;
-      }
-      if (pSerial > 0) {
-        if (Source == "UxIx2") {
-          LectureUxIx2();
-          PeriodeProgMillis = 400;
-        }
-        if (Source == "UxIx3") {
-          Lecture_JSY333();
-          PeriodeProgMillis = 800;
-          if (Serial2V == 19200) PeriodeProgMillis = 500;
-        }
-        if (Source == "Linky") {
-          LectureLinky();
-          PeriodeProgMillis = 2;
-        }
-      }
-      if (Source == "Enphase") {
-        LectureEnphase();
-        LastRMS_Millis = millis();
-        PeriodeProgMillis = 600 + ralenti;  //On s'adapte à la vitesse réponse Envoy-S metered
-      }
-      if (Source == "SmartG") {
-        LectureSmartG();
-        LastRMS_Millis = millis();
-        PeriodeProgMillis = 300 + ralenti;  //On s'adapte à la vitesse réponse SmartGateways
-      }
-      if (Source == "HomeW") {
-        LectureHomeW();
-        LastRMS_Millis = millis();
-        PeriodeProgMillis = 300 + ralenti;  //On s'adapte à la vitesse réponse HomeWizard
-      }
-      if (Source == "ShellyEm") {
-        LectureShellyEm();
-        LastRMS_Millis = millis();
-        PeriodeProgMillis = 300 + ralenti;  //On adapte la vitesse pour ne pas surchargé Wifi.La gestion overproduction est toujours à 200ms
-      }
-      if (Source == "ShellyPro") {
-        LectureShellyProEm();
-        LastRMS_Millis = millis();
-        PeriodeProgMillis = 300 + ralenti;  //On adapte  la vitesse pour ne pas surchargé Wifi
-      }
 
-      if (Source == "Ext") {
-        CallESP32_Externe();
-        LastRMS_Millis = millis();
-        PeriodeProgMillis = 800 + ralenti;  //Après pour ne pas surchargé Wifi
-      }
-      if (Source == "Pmqtt") {
-        PeriodeProgMillis = 600;
-        LastRMS_Millis = millis();
-        UpdatePmqtt();
+      // Canal M (Maison) — pilote le routage
+      Lecture_Source(Source, 'M');
+
+      // Canal T (Triac) — optionnel
+      if (Source_T != "NotDef" && Source_T != Source) {
+        Lecture_Source(Source_T, 'T');
       }
     }
     delay(2);

--- a/Source_MQTT.ino
+++ b/Source_MQTT.ino
@@ -2,51 +2,76 @@
 // ******************************************************
 // * Informations de puissance reçue via un Broker MQTT *
 // ******************************************************
+// Pmqtt peut être utilisée comme Source_M (topic = TopicP) ou Source_T (topic = TopicP_T).
+// Les valeurs reçues sont mises en cache dans deux jeux distincts (PwMQTT/PwMQTT_T, etc.)
+// par le callback MQTT (voir EnvoiMQTT.ino). UpdatePmqtt() choisit le bon jeu selon
+// le canal de lecture courant et écrit le résultat via les pointeurs canal.
 void UpdatePmqtt() {
-  float Pw = PfloatMax(PwMQTT);
-  float Pf = 1;
-  if (P_MQTT_Brute.indexOf("Pf") > 0) {
-    Pf = abs(PfMQTT);
+  // Sélectionne la source de vérité (M ou T) selon le canal courant
+  float Pw_raw, Pva_raw, Pf_raw;
+  String Brute;
+  unsigned long lastReceived;
+  if (canal_lecture_courant == 'T') {
+    Pw_raw  = PwMQTT_T;
+    Pva_raw = PvaMQTT_T;
+    Pf_raw  = PfMQTT_T;
+    Brute   = P_MQTT_Brute_T;
+    lastReceived = LastPwMQTTMillis_T;
+  } else {
+    Pw_raw  = PwMQTT;
+    Pva_raw = PvaMQTT;
+    Pf_raw  = PfMQTT;
+    Brute   = P_MQTT_Brute;
+    lastReceived = LastPwMQTTMillis;
   }
-  if (P_MQTT_Brute.indexOf("Pva") > 0) {
-    if (PvaMQTT != 0) {
-      Pf = abs(Pw / PfloatMax(PvaMQTT));
+
+  float Pw = PfloatMax(Pw_raw);
+  float Pf = 1;
+  if (Brute.indexOf("Pf") > 0) {
+    Pf = abs(Pf_raw);
+  }
+  if (Brute.indexOf("Pva") > 0) {
+    if (Pva_raw != 0) {
+      Pf = abs(Pw / PfloatMax(Pva_raw));
     }
   }
-  if (P_MQTT_Brute.indexOf("Pva") > 0 || P_MQTT_Brute.indexOf("Pf") > 0) {
+  if (Brute.indexOf("Pva") > 0 || Brute.indexOf("Pf") > 0) {
     Pva_valide = true;
   } else {
     Pva_valide = false;
   }
   if (Pf > 1) Pf = 1;
+
+  // Écriture via les pointeurs canal (M ou T)
   if (Pw >= 0) {
-    PuissanceS_M_inst = Pw;
-    PuissanceI_M_inst = 0;
+    *pPuissanceS_inst = Pw;
+    *pPuissanceI_inst = 0;
     if (Pf > 0.01) {
-      PVAS_M_inst = PfloatMax(Pw / Pf);
+      *pPVAS_inst = PfloatMax(Pw / Pf);
     } else {
-      PVAS_M_inst = 0;
+      *pPVAS_inst = 0;
     }
-    PVAI_M_inst = 0;
-    EASfloat += Pw / 6000.0;               // Watt Hour,Every 600ms. Soutirée
-    Energie_M_Soutiree = int(EASfloat);  // Watt Hour,Every 40ms. Soutirée
+    *pPVAI_inst = 0;
+    *pEASfloat += Pw / 6000.0;               // Watt Hour, every 600ms. Soutirée
+    *pEnergie_Soutiree = long(*pEASfloat);
   } else {
-    PuissanceS_M_inst = 0;
-    PuissanceI_M_inst = -Pw;
+    *pPuissanceS_inst = 0;
+    *pPuissanceI_inst = -Pw;
     if (Pf > 0.01) {
-      PVAI_M_inst = PfloatMax(-Pw / Pf);
+      *pPVAI_inst = PfloatMax(-Pw / Pf);
     } else {
-      PVAI_M_inst = 0;
+      *pPVAI_inst = 0;
     }
-    PVAS_M_inst = 0;
-    EAIfloat += -Pw / 6000.0;
-    Energie_M_Injectee = long(EAIfloat);
+    *pPVAS_inst = 0;
+    *pEAIfloat += -Pw / 6000.0;
+    *pEnergie_Injectee = long(*pEAIfloat);
   }
 
   filtre_puissance();
 
-  if (P_MQTT_Brute.indexOf("Pw") > 0) EnergieActiveValide = true;
-  if (millis() - LastPwMQTTMillis < 30000) PuissanceRecue = true;  //Reset du Watchdog si trame  MQTT reçue avec au minimum Pw récente
+  if (Brute.indexOf("Pw") > 0) EnergieActiveValide = true;
+  // Le watchdog n'est rafraîchi que par la source M (qui pilote le routage)
+  if (canal_lecture_courant == 'M' && millis() - lastReceived < 30000) PuissanceRecue = true;
 
   if (cptLEDyellow > 30) {
     cptLEDyellow = 4;

--- a/Source_ShellyEm.ino
+++ b/Source_ShellyEm.ino
@@ -120,21 +120,22 @@ void LectureShellyEm() {
     }
     total_E_soutire += ValJson("total", Shelly_Data);
     total_E_injecte += ValJson("total_returned", Shelly_Data);
-    Energie_M_Soutiree = int(total_E_soutire);
-    Energie_M_Injectee = int(total_E_injecte);
+    // Triphasé : voie principale écrite via pointeurs canal (alimente _M ou _T)
+    *pEnergie_Soutiree = int(total_E_soutire);
+    *pEnergie_Injectee = int(total_E_injecte);
     if (total_Pw == 0) {
       total_Pva = 0;
     }
     if (total_Pw > 0) {
-      PuissanceS_M_inst = total_Pw;
-      PuissanceI_M_inst = 0;
-      PVAS_M_inst = total_Pva;
-      PVAI_M_inst = 0;
+      *pPuissanceS_inst = total_Pw;
+      *pPuissanceI_inst = 0;
+      *pPVAS_inst = total_Pva;
+      *pPVAI_inst = 0;
     } else {
-      PuissanceS_M_inst = 0;
-      PuissanceI_M_inst = -total_Pw;
-      PVAI_M_inst = total_Pva;
-      PVAS_M_inst = 0;
+      *pPuissanceS_inst = 0;
+      *pPuissanceI_inst = -total_Pw;
+      *pPVAI_inst = total_Pva;
+      *pPVAS_inst = 0;
     }
   } else if (voie < 3) {  //Monophasé Shelly Em de base
     ShEm_dataBrute = "<strong>Voie : " + String(Voie) + "</strong><br>" + Shelly_Data;
@@ -145,32 +146,33 @@ void LectureShellyEm() {
       pf = ValJson("pf", Shelly_Data);
       pf = abs(pf);
       if (pf > 1) pf = 1;
-      if (Voie == voie) {  //voie du routeur
+      if (Voie == voie) {  // Voie principale (configurée) : écrit via pointeurs canal (_M ou _T)
         if (Pw >= 0) {
-          PuissanceS_M_inst = Pw;
-          PuissanceI_M_inst = 0;
+          *pPuissanceS_inst = Pw;
+          *pPuissanceI_inst = 0;
           if (pf > 0.01) {
-            PVAS_M_inst = PfloatMax(Pw / pf);
+            *pPVAS_inst = PfloatMax(Pw / pf);
           } else {
-            PVAS_M_inst = 0;
+            *pPVAS_inst = 0;
           }
-          PVAI_M_inst = 0;
+          *pPVAI_inst = 0;
         } else {
-          PuissanceS_M_inst = 0;
-          PuissanceI_M_inst = -Pw;
+          *pPuissanceS_inst = 0;
+          *pPuissanceI_inst = -Pw;
           if (pf > 0.01) {
-            PVAI_M_inst = PfloatMax(-Pw / pf);
+            *pPVAI_inst = PfloatMax(-Pw / pf);
           } else {
-            PVAI_M_inst = 0;
+            *pPVAI_inst = 0;
           }
-          PVAS_M_inst = 0;
+          *pPVAS_inst = 0;
         }
-        Energie_M_Soutiree = int(ValJson("total", Shelly_Data));
-        Energie_M_Injectee = int(ValJson("total_returned", Shelly_Data));
-        PowerFactor_M = pf;
-        Tension_M = voltage;
+        *pEnergie_Soutiree = int(ValJson("total", Shelly_Data));
+        *pEnergie_Injectee = int(ValJson("total_returned", Shelly_Data));
+        *pPowerFactor = pf;
+        *pTension = voltage;
         Pva_valide = true;
-      } else {  // voie secondaire
+      } else if (canal_lecture_courant == 'M') {
+        // Voie secondaire (mode 2-voies) : hardcodée _T, uniquement quand ShellyEm est en Source_M
         if (LissageLong) {
           PwMoy2 = 0.2 * Pw + 0.8 * PwMoy2;  //Lissage car moins de mesure sur voie secondaire
           pfMoy2 = 0.2 * pf + 0.8 * pfMoy2;
@@ -207,63 +209,68 @@ void LectureShellyEm() {
     Voie = voie % 2;
     ShEm_dataBrute = "<strong>Shelly Em Gen3 Voie : " + String(Voie) + "</strong><br>" + Shelly_Data;
     if (Shelly_Data.indexOf("ssid") > 0) {  // Donnée valide
+      // Gen3 voie principale (configurée) : écrit via pointeurs canal
       Shelly_Data = SubJson("em1:" + String(Voie), "}", Shelly_Data);
       Pw = PfloatMax(ValJson("act_power", Shelly_Data));
       pf = ValJson("pf", Shelly_Data);
       voltage = ValJson("voltage", Shelly_Data);
       if (Pw >= 0) {
-        PuissanceS_M_inst = Pw;
-        PuissanceI_M_inst = 0;
+        *pPuissanceS_inst = Pw;
+        *pPuissanceI_inst = 0;
         if (pf > 0.01) {
-          PVAS_M_inst = PfloatMax(Pw / pf);
+          *pPVAS_inst = PfloatMax(Pw / pf);
         } else {
-          PVAS_M_inst = 0;
+          *pPVAS_inst = 0;
         }
-        PVAI_M_inst = 0;
+        *pPVAI_inst = 0;
       } else {
-        PuissanceS_M_inst = 0;
-        PuissanceI_M_inst = -Pw;
+        *pPuissanceS_inst = 0;
+        *pPuissanceI_inst = -Pw;
         if (pf > 0.01) {
-          PVAI_M_inst = PfloatMax(-Pw / pf);
+          *pPVAI_inst = PfloatMax(-Pw / pf);
         } else {
-          PVAI_M_inst = 0;
+          *pPVAI_inst = 0;
         }
-        PVAS_M_inst = 0;
+        *pPVAS_inst = 0;
       }
       Shelly_Data = SubJson("em1data:" + String(Voie), "}", ShEm_dataBrute);
-      Energie_M_Soutiree = int(ValJson("total_act_energy", Shelly_Data));
-      Energie_M_Injectee = int(ValJson("total_act_ret_energy", Shelly_Data));
-      PowerFactor_M = pf;
-      Tension_M = voltage;
+      *pEnergie_Soutiree = int(ValJson("total_act_energy", Shelly_Data));
+      *pEnergie_Injectee = int(ValJson("total_act_ret_energy", Shelly_Data));
+      *pPowerFactor = pf;
+      *pTension = voltage;
       Pva_valide = true;
-      Voie = (Voie + 1) % 2;
-      Shelly_Data = SubJson("em1:" + String(Voie), "}", ShEm_dataBrute);
-      Pw = PfloatMax(ValJson("act_power", Shelly_Data));
-      pf = ValJson("pf", Shelly_Data);
-      if (Pw >= 0) {
-        PuissanceS_T_inst = Pw;
-        PuissanceI_T_inst = 0;
-        if (pf > 0.01) {
-          PVAS_T_inst = PfloatMax(Pw / pf);
+
+      // Gen3 voie secondaire (mode 2-voies) : hardcodée _T, uniquement quand ShellyEm est en Source_M
+      if (canal_lecture_courant == 'M') {
+        Voie = (Voie + 1) % 2;
+        Shelly_Data = SubJson("em1:" + String(Voie), "}", ShEm_dataBrute);
+        Pw = PfloatMax(ValJson("act_power", Shelly_Data));
+        pf = ValJson("pf", Shelly_Data);
+        if (Pw >= 0) {
+          PuissanceS_T_inst = Pw;
+          PuissanceI_T_inst = 0;
+          if (pf > 0.01) {
+            PVAS_T_inst = PfloatMax(Pw / pf);
+          } else {
+            PVAS_T_inst = 0;
+          }
+          PVAI_T_inst = 0;
         } else {
+          PuissanceS_T_inst = 0;
+          PuissanceI_T_inst = -Pw;
+          if (pf > 0.01) {
+            PVAI_T_inst = PfloatMax(-Pw / pf);
+          } else {
+            PVAI_T_inst = 0;
+          }
           PVAS_T_inst = 0;
         }
-        PVAI_T_inst = 0;
-      } else {
-        PuissanceS_T_inst = 0;
-        PuissanceI_T_inst = -Pw;
-        if (pf > 0.01) {
-          PVAI_T_inst = PfloatMax(-Pw / pf);
-        } else {
-          PVAI_T_inst = 0;
-        }
-        PVAS_T_inst = 0;
+        Shelly_Data = SubJson("em1data:" + String(Voie), "}", ShEm_dataBrute);
+        Energie_T_Soutiree = int(ValJson("total_act_energy", Shelly_Data));
+        Energie_T_Injectee = int(ValJson("total_act_ret_energy", Shelly_Data));
+        PowerFactor_T = pf;
+        Tension_T = voltage;
       }
-      Shelly_Data = SubJson("em1data:" + String(Voie), "}", ShEm_dataBrute);
-      Energie_T_Soutiree = int(ValJson("total_act_energy", Shelly_Data));
-      Energie_T_Injectee = int(ValJson("total_act_ret_energy", Shelly_Data));
-      PowerFactor_T = pf;
-      Tension_T = voltage;
     }
   }
   filtre_puissance();

--- a/Source_ShellyProEm.ino
+++ b/Source_ShellyProEm.ino
@@ -128,30 +128,31 @@ void LectureShellyProEm() {
     voltage = (Tension_M1 + Tension_M2 + Tension_M3) / 3;
     pf = abs((pf1 + pf2 + pf3) / 3);
     if (pf > 1) pf = 1;
+    // Triphasé : voie principale écrite via pointeurs canal (_M ou _T)
     if (Pw >= 0) {
-      PuissanceS_M_inst = Pw;
-      PuissanceI_M_inst = 0;
+      *pPuissanceS_inst = Pw;
+      *pPuissanceI_inst = 0;
       if (pf > 0.01) {
-        PVAS_M_inst = PfloatMax(Pw / pf);
+        *pPVAS_inst = PfloatMax(Pw / pf);
       } else {
-        PVAS_M_inst = 0;
+        *pPVAS_inst = 0;
       }
-      PVAI_M_inst = 0;
+      *pPVAI_inst = 0;
     } else {
-      PuissanceS_M_inst = 0;
-      PuissanceI_M_inst = -Pw;
+      *pPuissanceS_inst = 0;
+      *pPuissanceI_inst = -Pw;
       if (pf > 0.01) {
-        PVAI_M_inst = PfloatMax(-Pw / pf);
+        *pPVAI_inst = PfloatMax(-Pw / pf);
       } else {
-        PVAI_M_inst = 0;
+        *pPVAI_inst = 0;
       }
-      PVAS_M_inst = 0;
+      *pPVAS_inst = 0;
     }
     tmp = PrefiltreJson("emdata:0", ":", Shelly_Data);      // ADD PERSO
-    Energie_M_Soutiree = myLongJson("total_act", tmp);      // ADD PERSO
-    Energie_M_Injectee = myLongJson("total_act_ret", tmp);  // ADD PERSO
-    PowerFactor_M = pf;
-    Tension_M = voltage;
+    *pEnergie_Soutiree = myLongJson("total_act", tmp);      // ADD PERSO
+    *pEnergie_Injectee = myLongJson("total_act_ret", tmp);  // ADD PERSO
+    *pPowerFactor = pf;
+    *pTension = voltage;
     Pva_valide = true;
   } else if (Shelly_Name == "shellypro3em" && Shelly_Triphase_As_Monophase) {
     // on utilise le code ASCII de a (97) pour obtenir le prefix de la phase. Voie 0=a 1=b 2=c
@@ -167,30 +168,31 @@ void LectureShellyProEm() {
     pf = abs(ValJson(Shelly_Phase + "_pf", tmp));
 
     if (pf > 1) pf = 1;
+    // Triphase utilisé en monophase : écrit via pointeurs canal (_M ou _T)
     if (Pw >= 0) {
-      PuissanceS_M_inst = Pw;
-      PuissanceI_M_inst = 0;
+      *pPuissanceS_inst = Pw;
+      *pPuissanceI_inst = 0;
       if (pf > 0.01) {
-        PVAS_M_inst = PfloatMax(Pw / pf);
+        *pPVAS_inst = PfloatMax(Pw / pf);
       } else {
-        PVAS_M_inst = 0;
+        *pPVAS_inst = 0;
       }
-      PVAI_M_inst = 0;
+      *pPVAI_inst = 0;
     } else {
-      PuissanceS_M_inst = 0;
-      PuissanceI_M_inst = -Pw;
+      *pPuissanceS_inst = 0;
+      *pPuissanceI_inst = -Pw;
       if (pf > 0.01) {
-        PVAI_M_inst = PfloatMax(-Pw / pf);
+        *pPVAI_inst = PfloatMax(-Pw / pf);
       } else {
-        PVAI_M_inst = 0;
+        *pPVAI_inst = 0;
       }
-      PVAS_M_inst = 0;
+      *pPVAS_inst = 0;
     }
-    tmp = PrefiltreJson("emdata:0", ":", Shelly_Data);                             // ADD PERSO
-    Energie_M_Soutiree = myLongJson(Shelly_Phase + "_total_act_energy", tmp);      // ADD PERSO
-    Energie_M_Injectee = myLongJson(Shelly_Phase + "_total_act_ret_energy", tmp);  // ADD PERSO
-    PowerFactor_M = pf;
-    Tension_M = voltage;
+    tmp = PrefiltreJson("emdata:0", ":", Shelly_Data);                              // ADD PERSO
+    *pEnergie_Soutiree = myLongJson(Shelly_Phase + "_total_act_energy", tmp);      // ADD PERSO
+    *pEnergie_Injectee = myLongJson(Shelly_Phase + "_total_act_ret_energy", tmp);  // ADD PERSO
+    *pPowerFactor = pf;
+    *pTension = voltage;
     Pva_valide = true;
   } else if (Shelly_Name == "shellypro3em") {
     // 3 em Monophasé : Voie != 3
@@ -202,33 +204,34 @@ void LectureShellyProEm() {
     pf = ValJson("pf", tmp);
     pf = abs(pf);
     if (pf > 1) pf = 1;
-    if (Voie == voie) {  // voie du routeur
+    if (Voie == voie) {  // Voie du routeur : écrite via pointeurs canal (_M ou _T)
       if (Pw >= 0) {
-        PuissanceS_M_inst = Pw;
-        PuissanceI_M_inst = 0;
+        *pPuissanceS_inst = Pw;
+        *pPuissanceI_inst = 0;
         if (pf > 0.01) {
-          PVAS_M_inst = PfloatMax(Pw / pf);
+          *pPVAS_inst = PfloatMax(Pw / pf);
         } else {
-          PVAS_M_inst = 0;
+          *pPVAS_inst = 0;
         }
-        PVAI_M_inst = 0;
+        *pPVAI_inst = 0;
       } else {
-        PuissanceS_M_inst = 0;
-        PuissanceI_M_inst = -Pw;
+        *pPuissanceS_inst = 0;
+        *pPuissanceI_inst = -Pw;
         if (pf > 0.01) {
-          PVAI_M_inst = PfloatMax(-Pw / pf);
+          *pPVAI_inst = PfloatMax(-Pw / pf);
         } else {
-          PVAI_M_inst = 0;
+          *pPVAI_inst = 0;
         }
-        PVAS_M_inst = 0;
+        *pPVAS_inst = 0;
       }
       tmp = PrefiltreJson("em1data:" + String(Voie), ":", Shelly_Data);  // ADD PERSO
-      Energie_M_Soutiree = myLongJson("total_act_energy", tmp);          // ADD PERSO
-      Energie_M_Injectee = myLongJson("total_act_ret_energy", tmp);      // ADD PERSO
-      PowerFactor_M = pf;
-      Tension_M = voltage;
+      *pEnergie_Soutiree = myLongJson("total_act_energy", tmp);          // ADD PERSO
+      *pEnergie_Injectee = myLongJson("total_act_ret_energy", tmp);      // ADD PERSO
+      *pPowerFactor = pf;
+      *pTension = voltage;
       Pva_valide = true;
-    } else {  // voie secondaire
+    } else if (canal_lecture_courant == 'M') {
+      // Voie secondaire (mode 2-voies) : hardcodée _T, uniquement quand ShellyProEm est en Source_M
       if (LissageLong) {
         PwMoy2 = 0.2 * Pw + 0.8 * PwMoy2;  // Lissage car moins de mesure sur voie secondaire
         pfMoy2 = 0.2 * pf + 0.8 * pfMoy2;
@@ -277,33 +280,34 @@ void LectureShellyProEm() {
       pf = ValJson("pf", tmp);                                       // ADD PERSO
       pf = abs(pf);
       if (pf > 1) pf = 1;
-      if (Voie == voie) {  // voie du routeur
+      if (Voie == voie) {  // Voie du routeur : écrite via pointeurs canal (_M ou _T)
         if (Pw >= 0) {
-          PuissanceS_M_inst = Pw;
-          PuissanceI_M_inst = 0;
+          *pPuissanceS_inst = Pw;
+          *pPuissanceI_inst = 0;
           if (pf > 0.01) {
-            PVAS_M_inst = PfloatMax(Pw / pf);
+            *pPVAS_inst = PfloatMax(Pw / pf);
           } else {
-            PVAS_M_inst = 0;
+            *pPVAS_inst = 0;
           }
-          PVAI_M_inst = 0;
+          *pPVAI_inst = 0;
         } else {
-          PuissanceS_M_inst = 0;
-          PuissanceI_M_inst = -Pw;
+          *pPuissanceS_inst = 0;
+          *pPuissanceI_inst = -Pw;
           if (pf > 0.01) {
-            PVAI_M_inst = PfloatMax(-Pw / pf);
+            *pPVAI_inst = PfloatMax(-Pw / pf);
           } else {
-            PVAI_M_inst = 0;
+            *pPVAI_inst = 0;
           }
-          PVAS_M_inst = 0;
+          *pPVAS_inst = 0;
         }
         tmp = PrefiltreJson("em1data:" + String(Voie), ":", Shelly_Data);  // ADD PERSO
-        Energie_M_Soutiree = myLongJson("total_act_energy", tmp);          // ADD PERSO
-        Energie_M_Injectee = myLongJson("total_act_ret_energy", tmp);      // ADD PERSO
-        PowerFactor_M = pf;
-        Tension_M = voltage;
+        *pEnergie_Soutiree = myLongJson("total_act_energy", tmp);          // ADD PERSO
+        *pEnergie_Injectee = myLongJson("total_act_ret_energy", tmp);      // ADD PERSO
+        *pPowerFactor = pf;
+        *pTension = voltage;
         Pva_valide = true;
-      } else {  // voie secondaire
+      } else if (canal_lecture_courant == 'M') {
+        // Voie secondaire (mode 2-voies) : hardcodée _T, uniquement quand ShellyProEm est en Source_M
         if (LissageLong) {
           PwMoy2 = 0.2 * Pw + 0.8 * PwMoy2;  // Lissage car moins de mesure sur voie secondaire
           pfMoy2 = 0.2 * pf + 0.8 * pfMoy2;

--- a/Source_UxI.ino
+++ b/Source_UxI.ino
@@ -54,39 +54,34 @@ void ComputePower() {
     Ief2 += sq(I);
     PWcal += V * I;
   }
-  Uef2 = Uef2 / 100.0;       //square of voltage
-  Tension_M = sqrt(Uef2);    //RMS voltage
-  Ief2 = Ief2 / 100.0;       //square of current
-  Intensite_M = sqrt(Ief2);  // RMS current
+  // Écriture via pointeurs canal : alimente _M ou _T selon Set_Canal_Lecture()
+  Uef2 = Uef2 / 100.0;        //square of voltage
+  *pTension = sqrt(Uef2);     //RMS voltage
+  Ief2 = Ief2 / 100.0;        //square of current
+  *pIntensite = sqrt(Ief2);   // RMS current
   PWcal = PfloatMax(PWcal / 100.0);
-  float PVA = PfloatMax(floor(Tension_M * Intensite_M));
+  float PVA = PfloatMax(floor((*pTension) * (*pIntensite)));
   float PowerFactor = 0;
   if (PVA > 0) {
     PowerFactor = floor(100.0 * PWcal / PVA) / 100.0;
   }
-  PowerFactor_M = PowerFactor;
+  *pPowerFactor = PowerFactor;
   if (PWcal >= 0) {
-    EASfloat += PWcal / 90000.0;         // Watt Hour,Every 40ms. Soutirée
-   
-    // PhDV61
-    Energie_M_Soutiree_double = EASfloat; // compteur float sauvegardé énergie totale soutirée pour reset
-
-    Energie_M_Soutiree = long(EASfloat);  
-    PuissanceS_M_inst = PWcal;
-    PuissanceI_M_inst = 0;
-    PVAS_M_inst = PVA;
-    PVAI_M_inst = 0;
+    *pEASfloat += PWcal / 90000.0;         // Watt Hour,Every 40ms. Soutirée
+    *pEnergie_Soutiree_double = *pEASfloat; // PhDV61 : compteur double sauvegardé pour reset
+    *pEnergie_Soutiree = long(*pEASfloat);
+    *pPuissanceS_inst = PWcal;
+    *pPuissanceI_inst = 0;
+    *pPVAS_inst = PVA;
+    *pPVAI_inst = 0;
   } else {
-    EAIfloat += -PWcal / 90000.0;
-    Energie_M_Injectee = long(EAIfloat);
-   
-      // PhDV61
-    Energie_M_Injectee_double = EAIfloat; // compteur sauvegardé énergie totale injectée pour reset
-
-    PuissanceS_M_inst = 0;
-    PuissanceI_M_inst = -PWcal;
-    PVAS_M_inst = 0;
-    PVAI_M_inst = PVA;
+    *pEAIfloat += -PWcal / 90000.0;
+    *pEnergie_Injectee = long(*pEAIfloat);
+    *pEnergie_Injectee_double = *pEAIfloat; // PhDV61 : compteur double sauvegardé pour reset
+    *pPuissanceS_inst = 0;
+    *pPuissanceI_inst = -PWcal;
+    *pPVAS_inst = 0;
+    *pPVAI_inst = PVA;
   }
   Pva_valide = true;
   if (cptLEDyellow > 30) {

--- a/Source_UxIx2.ino
+++ b/Source_UxIx2.ino
@@ -52,7 +52,9 @@ void LectureUxIx2() {  //Ecriture et Lecture port série du JSY-MK-194  .
     Sens_1 = ByteArray[27];  // Sens 1
     Sens_2 = ByteArray[28];
 
-    //Données du Triac
+    // Voie 1 du JSY = Triac → toujours écrit dans les variables _T.
+    // Cette voie est utilisée que UxIx2 soit appelée comme Source (en remplissant Maison+Triac)
+    // ou comme Source_T (on ne lit alors que la voie 1 et on l'écrit dans _T).
     Tension_T = LesDatas[0] * .0001;
     Intensite_T = LesDatas[1] * .0001;
     float Puiss_1 = PfloatMax(LesDatas[2] * .0001);
@@ -75,28 +77,33 @@ void LectureUxIx2() {  //Ecriture et Lecture port série du JSY-MK-194  .
       PVAI_T_inst = 0;
       PVAS_T_inst = PVA1;
     }
-    // Données générale de la Maison
-    Tension_M = LesDatas[8] * .0001;
-    Intensite_M = LesDatas[9] * .0001;
-    float Puiss_2 = PfloatMax(LesDatas[10] * .0001);
-    Energie_M_Soutiree = int(LesDatas[11] * .1);
-    PowerFactor_M = LesDatas[12] * .001;
-    Energie_M_Injectee = int(LesDatas[13] * .1);
-    float PVA2 = 0;
-    if (PowerFactor_M > 0) {
-      PVA2 = Puiss_2 / PowerFactor_M;
+
+    // Voie 2 du JSY = Maison → écrite uniquement quand UxIx2 est appelée comme Source_M
+    // (canal 'M'). En canal 'T', la voie 2 est ignorée pour ne pas polluer _M.
+    if (canal_lecture_courant == 'M') {
+      Tension_M = LesDatas[8] * .0001;
+      Intensite_M = LesDatas[9] * .0001;
+      float Puiss_2 = PfloatMax(LesDatas[10] * .0001);
+      Energie_M_Soutiree = int(LesDatas[11] * .1);
+      PowerFactor_M = LesDatas[12] * .001;
+      Energie_M_Injectee = int(LesDatas[13] * .1);
+      float PVA2 = 0;
+      if (PowerFactor_M > 0) {
+        PVA2 = Puiss_2 / PowerFactor_M;
+      }
+      if (Sens_2 > 0) {  //Injection en entrée de Maison
+        PuissanceI_M_inst = Puiss_2;
+        PuissanceS_M_inst = 0;
+        PVAI_M_inst = PVA2;
+        PVAS_M_inst = 0;
+      } else {
+        PuissanceS_M_inst = Puiss_2;
+        PuissanceI_M_inst = 0;
+        PVAI_M_inst = 0;
+        PVAS_M_inst = PVA2;
+      }
     }
-    if (Sens_2 > 0) {  //Injection en entrée de Maison
-      PuissanceI_M_inst = Puiss_2;
-      PuissanceS_M_inst = 0;
-      PVAI_M_inst = PVA2;
-      PVAS_M_inst = 0;
-    } else {
-      PuissanceS_M_inst = Puiss_2;
-      PuissanceI_M_inst = 0;
-      PVAI_M_inst = 0;
-      PVAS_M_inst = PVA2;
-    }
+
     filtre_puissance();
     EnergieActiveValide = true;
     Pva_valide = true;

--- a/Source_UxIx3.ino
+++ b/Source_UxIx3.ino
@@ -114,32 +114,32 @@ void Lecture_JSY333() {
     Energie_Jour_JSY_Soutiree =  JSY_Soutire - Energie_Minuit_JSY_Soutiree;
     Energie_Jour_JSY_Injectee =  JSY_Injecte - Energie_Minuit_JSY_Injectee;
 
+    // Variables "somme" écrites via pointeurs canal (alimente _M ou _T selon Set_Canal_Lecture).
+    // Les variables par phase (Tension_M1/M2/M3, etc.) restent en dur sur _M — limitation
+    // documentée : quand UxIx3 est utilisée en Source_T, ces variables reflètent en réalité
+    // les phases du Triac mais conservent leur nom historique.
     if (injection) {
-      PuissanceS_M_inst = 0;
-      PuissanceI_M_inst = ((float)((float)(Lecture333[21] * 16777216) + (float)(Lecture333[22] * 65536) + (float)(Lecture333[23] * 256) + (float)Lecture333[24]));
+      *pPuissanceS_inst = 0;
+      *pPuissanceI_inst = ((float)((float)(Lecture333[21] * 16777216) + (float)(Lecture333[22] * 65536) + (float)(Lecture333[23] * 256) + (float)Lecture333[24]));
 
-      PVAS_M_inst = 0;
-      PVAI_M_inst = abs(PVA_M_inst1 + PVA_M_inst2 + PVA_M_inst3);  // car la somme des puissances apparentes "signées" est négative puisqu'en "injection" au global
+      *pPVAS_inst = 0;
+      *pPVAI_inst = abs(PVA_M_inst1 + PVA_M_inst2 + PVA_M_inst3);  // car la somme des puissances apparentes "signées" est négative puisqu'en "injection" au global
       // PhDV61 : on considère que cette puissance active "globale" a duré "delta_temps", et on l'intègre donc pour obtenir une énergie en Wh
-      
-      // --->>> Modification PhDV61
-      delta_Energie = ( (float) delta_temps / 1000.0) * ( PuissanceI_M_inst / 3600.0);
+      delta_Energie = ( (float) delta_temps / 1000.0) * ( (*pPuissanceI_inst) / 3600.0);
 
-      Energie_M_Injectee_double += delta_Energie;
-      Energie_M_Injectee  = (long) Energie_M_Injectee_double; // On conserve la partie entière - Energie_M_Injectee est un long !
-    }  
+      *pEnergie_Injectee_double += delta_Energie;
+      *pEnergie_Injectee = (long)(*pEnergie_Injectee_double); // On conserve la partie entière - long !
+    }
       else {  // soutirage
-      PuissanceI_M_inst = 0;
-      PuissanceS_M_inst = ((float)((float)(Lecture333[21] * 16777216) + (float)(Lecture333[22] * 65536) + (float)(Lecture333[23] * 256) + (float)Lecture333[24]));
-      PVAI_M_inst = 0;
-      PVAS_M_inst = PVA_M_inst1 + PVA_M_inst2 + PVA_M_inst3;
-      // PhDV61 : on considère que cette puissance active "globale" a duré "delta_temps", et on l'intègre donc pour obtenir pour obtenir une énergie en Wh
- 
-      // --->>> Modification PhDV61
-      delta_Energie = ( (float) delta_temps / 1000.0) * ( PuissanceS_M_inst / 3600.0);
-      
-      Energie_M_Soutiree_double += delta_Energie;
-      Energie_M_Soutiree  = (long) Energie_M_Soutiree_double; // On conserve la partie entière - Energie_M_Soutiree est un long !
+      *pPuissanceI_inst = 0;
+      *pPuissanceS_inst = ((float)((float)(Lecture333[21] * 16777216) + (float)(Lecture333[22] * 65536) + (float)(Lecture333[23] * 256) + (float)Lecture333[24]));
+      *pPVAI_inst = 0;
+      *pPVAS_inst = PVA_M_inst1 + PVA_M_inst2 + PVA_M_inst3;
+      // PhDV61 : on considère que cette puissance active "globale" a duré "delta_temps", et on l'intègre donc pour obtenir une énergie en Wh
+      delta_Energie = ( (float) delta_temps / 1000.0) * ( (*pPuissanceS_inst) / 3600.0);
+
+      *pEnergie_Soutiree_double += delta_Energie;
+      *pEnergie_Soutiree = (long)(*pEnergie_Soutiree_double); // On conserve la partie entière - long !
     }
  
     MK333_dataBrute = "";
@@ -160,11 +160,11 @@ void Lecture_JSY333() {
     else
       MK333_dataBrute += "<br>Phase3 : " + String(Tension_M3) + "V x +" + String(Intensite_M3) + "A = +" + String(int(PVA_M_inst3)) + "VA</br>";
 
-// Modification ordre d'apparition PhDV61
-    if (PVAS_M_inst == 0)
-      MK333_dataBrute += "<br>Puissance apparente injectée : " + String(PVAI_M_inst) + "VA</br>";
+// Modification ordre d'apparition PhDV61. Lecture via pointeurs canal pour rester cohérent.
+    if (*pPVAS_inst == 0)
+      MK333_dataBrute += "<br>Puissance apparente injectée : " + String(*pPVAI_inst) + "VA</br>";
     else
-      MK333_dataBrute += "<br>Puissance apparente soutirée : " + String(PVAS_M_inst) + "VA</br>";
+      MK333_dataBrute += "<br>Puissance apparente soutirée : " + String(*pPVAS_inst) + "VA</br>";
  
       // traces PhDV61
       // MK333_dataBrute += "<br>delta Energie                : " + String(delta_Energie) + "Wh</br>"; 
@@ -175,10 +175,10 @@ void Lecture_JSY333() {
 //  Ajout puissances instantanées PhDV61
     MK333_dataBrute += "<br>PW_M1+2+3:("+String(PW_M1)+")+("+String(PW_M2)+")+("+String(PW_M3)+ ") W</br>";
 
-    if (PuissanceS_M_inst == 0)
-      MK333_dataBrute += "<br>Puissance active injectée    : " + String(PuissanceI_M_inst) + "W</br>";
+    if (*pPuissanceS_inst == 0)
+      MK333_dataBrute += "<br>Puissance active injectée    : " + String(*pPuissanceI_inst) + "W</br>";
     else
-      MK333_dataBrute += "<br>Puissance active soutirée    : " + String(PuissanceS_M_inst) + "W</br>";
+      MK333_dataBrute += "<br>Puissance active soutirée    : " + String(*pPuissanceS_inst) + "W</br>";
 
     if (PVA_M_inst1 != 0)
       MK333_dataBrute += "<br>Facteur de puissance phase 1 : " + String(abs(PW_inst1 / PVA_M_inst1)) + "</br>";

--- a/Stockage.ino
+++ b/Stockage.ino
@@ -308,6 +308,19 @@ void DeserializeConfiguration(String json) {
   pUxI = conf["pUxI"];
   pTemp = conf["pTemp"];
   Source = conf["Source"].as<String>();
+  // Migration vers le modèle Source / Source_T :
+  // - Si Source_T présent dans le JSON, on l'utilise tel quel
+  // - Sinon, on déduit selon la source historique :
+  //   - sources multi-mesures (UxIx2 / ShellyEm / ShellyProEm) → Source_T = Source
+  //     (préserve l'ancien comportement : la voie 2 alimente _T)
+  //   - toute autre source → Source_T = "NotDef" (pas de mesure Triac)
+  if (!conf["Source_T"].isNull()) {
+    Source_T = conf["Source_T"].as<String>();
+  } else if (Source == "UxIx2" || Source == "ShellyEm" || Source == "ShellyPro") {
+    Source_T = Source;
+  } else {
+    Source_T = "NotDef";
+  }
   RMSextIP = conf["RMSextIP"];
   RMSextIPauto = conf["RMSextIPauto"].isNull() ? RMSextIPauto : conf["RMSextIPauto"];
   EnphaseUser = conf["EnphaseUser"].as<String>();
@@ -322,6 +335,7 @@ void DeserializeConfiguration(String json) {
   MQTTPrefixEtat = conf["MQTTPrefixEtat"].as<String>();
   MQTTdeviceName = conf["MQTTdeviceName"].as<String>();
   TopicP = conf["TopicP"].as<String>();
+  TopicP_T = conf["TopicP_T"] | TopicP_T;  // Topic MQTT pour la source T (Pmqtt en Source_T)
   subMQTT = conf["subMQTT"];
   nomRouteur = conf["nomRouteur"].as<String>();
   nomSondeFixe = conf["nomSondeFixe"].as<String>();
@@ -439,6 +453,7 @@ String SerializeConfiguration() {
   conf["pUxI"] = pUxI;
   conf["pTemp"] = pTemp;
   conf["Source"] = Source;
+  conf["Source_T"] = Source_T;        // Source du canal T (Triac), "NotDef" si non utilisée
   conf["RMSextIP"] = RMSextIP;
   conf["RMSextIPauto"] = RMSextIPauto;
   conf["EnphaseUser"] = EnphaseUser;
@@ -457,6 +472,7 @@ String SerializeConfiguration() {
   conf["MQTTPrefixEtat"] = MQTTPrefixEtat;
   conf["MQTTdeviceName"] = MQTTdeviceName;
   conf["TopicP"] = TopicP;
+  conf["TopicP_T"] = TopicP_T;        // Topic MQTT pour la source T (Pmqtt)
   conf["subMQTT"] = subMQTT;
   conf["nomRouteur"] = nomRouteur;
   conf["nomSondeFixe"] = nomSondeFixe;


### PR DESCRIPTION
# Ajout d'une seconde source pour la mesure Triac (Source_T)

## Notes pour la revue

- **Rétrocompat 100%** : sans `Source_T` configurée (défaut après migration), comportement byte-identique à V17.19.
- **12 fichiers modifiés**. Les sources qui ne sont **pas** utilisables comme `Source_T` (`Source_EnphaseEnvoy.ino`, `Source_SmartG.ino`, `Source_HomeWizard.ino`, `Source_NotDef.ino`, `Source_Linky.ino`, `Source_Externe.ino`) sont **strictement inchangées**.
- **Aucune dépendance ajoutée**.
- **Migration auto** au boot via `Stockage.ino`, pas d'action utilisateur.
- Tester sur matériel : 1) booter avec un ancien `parametres.json` → comportement V17.19 ; 2) configurer `Source_T` via web UI → la mesure Triac apparaît dans la page Brute et en MQTT.

---

## Résumé

Le routeur a historiquement deux jeux de variables internes :
- **Mesure Maison** (variables `_M_*`) : puissance à l'entrée Maison — **pilote le routage**
- **Mesure Triac** (variables `_T_*`) : puissance délivrée à la sortie Triac — affichage et MQTT seulement

Avant cette PR, une **seule source** était configurable et alimentait au mieux les deux mesures (uniquement si son matériel le permettait). Cette PR introduit une **seconde source** dédiée à la mesure Triac, configurable indépendamment de la source qui fournit la mesure Maison.

La configuration devient :
- `Source` : la source qui fournit la **mesure Maison** (comme avant)
- `Source_T` : la source qui fournit la **mesure Triac** (nouveau, optionnel, défaut `"NotDef"`)

La fonctionnalité est **rétrocompatible** : un fichier `parametres.json` existant continue de fonctionner à l'identique.

---

## Motivation

Aujourd'hui un utilisateur qui dispose d'un capteur dédié à la mesure Maison (Shelly 3EM par exemple) et qui veut **également** mesurer la puissance qui passe réellement par la sortie Triac ne peut pas le faire avec un seul appareil.

Cette PR comble cette lacune : chaque source est dédiée à un rôle clair (Maison ou Triac) et alimente uniquement les variables qui lui correspondent.

---

## Cas d'usage typiques

| `Source` (Maison) | `Source_T` (Triac) | Utilité |
|---|---|---|
| Shelly 3EM | UxIx2 (voie 1) | Pilotage par Shelly + suivi précis Triac via JSY |
| Linky | UxI | Comptage officiel + ampèremètre dédié Triac |
| UxIx3 (triphasé) | Shelly Em | Maison triphasée + monitoring Triac monophasé |
| Shelly 3EM | UxIx3 | Triac triphasé mesuré par un second JSY-MK-333 |
| Pmqtt (`/maison`) | Pmqtt (`/triac`) | Deux topics MQTT distincts pour deux capteurs externes |

---

## Architecture

### Catégorisation des sources existantes

Avant cette PR, **trois sources sont "multi-mesures"** : elles fournissent simultanément les mesures Maison et Triac en un seul appel matériel.
- `UxIx2` (toujours, via les 2 voies du JSY-MK-194T)
- `ShellyEm` quand le **numéro de voie configuré** désigne un mode monophasé à 2 sondes (pas triphasé)
- `ShellyProEm` dans la même configuration

Toutes les autres sources (`UxI`, `Linky`, `Shelly 3EM`, `UxIx3`, `Enphase`, `SmartG`, `HomeW`, `Pmqtt`, `NotDef`, `Ext`) ne fournissent que la mesure Maison.

### Que fait cette PR

Pour les **sources multi-mesures** (voir glossaire) :
- En `Source` seule, comportement V17.19 préservé : la source alimente la mesure Maison ET la mesure Triac via son matériel
- En `Source_T`, la source n'alimente que la mesure Triac (la partie Maison est ignorée)

Pour **toutes les autres sources** qui n'alimentaient que la mesure Maison : la PR ajoute un mécanisme de pointeurs qui les fait écrire dans la mesure Maison **ou** dans la mesure Triac selon qu'elles sont configurées en `Source` ou en `Source_T`.

### Mécanisme d'indirection par pointeurs

Pour permettre à une même fonction de lecture d'alimenter au choix la mesure Maison ou la mesure Triac, on remplace les écritures en dur par des écritures via pointeurs globaux :

```cpp
// Avant : chaque source écrit en dur dans les variables Maison
PuissanceS_M_inst = Pw;
Energie_M_Soutiree = X;
Tension_M = U;

// Après : écriture via pointeurs (la cible est positionnée par le dispatcher)
*pPuissanceS_inst = Pw;
*pEnergie_Soutiree = X;
*pTension = U;
```

Les pointeurs sont positionnés par `Set_Canal_Lecture('M'|'T')` avant chaque appel de source. Le code des sources est inchangé conceptuellement : il écrit toujours dans "la cible courante", peu importe que ce soit Maison ou Triac.

### Cycle de mesure dans `Task_LectureRMS`

```
Toutes les PeriodeProgMillis ms :

  1. Lecture_Source(Source, 'M')
     - Set_Canal_Lecture('M') : pointeurs → variables _M (Maison)
     - appelle la fonction Lecture*() de la source Maison
     - filtre_puissance() filtre _M et _T

  2. Si Source_T != "NotDef" et Source_T != Source :
     Lecture_Source(Source_T, 'T')
     - Set_Canal_Lecture('T') : pointeurs → variables _T (Triac)
     - appelle la fonction Lecture*() de la source Triac
     - filtre_puissance() filtre _M et _T
```

---

## Modifications par fichier

| Fichier | Changements |
|---|---|
| `Solar_Router_V17_19.ino` | Nouvelles globales `Source_T`, `TopicP_T`, 17 pointeurs canal initialisés à la déclaration, accumulateurs T (`EASfloat_T`, `EAIfloat_T`, `Energie_T_Soutiree/Injectee_double`), `canal_lecture_courant`. Nouvelle fonction `Set_Canal_Lecture()`. `Lecture_Source()` accepte un paramètre `canal`. `setup()` et `Task_LectureRMS` simplifiés. |
| `Stockage.ino` | Sérialisation/désérialisation de `Source_T` et `TopicP_T`. Migration : si `Source_T` absent du JSON, déduit selon la source historique (sources multi-mesures → `Source_T = Source`, sinon `"NotDef"`). `filtre_puissance()` strictement inchangée vs V17.19. |
| `Source_UxI.ino` | Source utilisable comme `Source_T` : remplacement mécanique `_M_*` → `*p_*`. |
| `Source_UxIx3.ino` | Variables somme (`PuissanceS_M_inst`, `Energie_M_*`, etc.) refactorées avec pointeurs. Variables par phase (`Tension_M1/M2/M3`, `Intensite_M1/M2/M3`, `PW_M1/M2/M3`) conservent leur préfixe `_M` même en `Source_T` (limitation documentée). |
| `Source_UxIx2.ino`, `Source_ShellyEm.ino`, `Source_ShellyProEm.ino` | Sources multi-mesures : la voie principale est écrite via pointeurs (alimente `_M` quand la source est en `Source`, `_T` quand elle est en `Source_T`), la voie secondaire reste hardcodée `_T` mais gardée par `if (canal_lecture_courant == 'M')` (ignorée si la source est en `Source_T`). |
| `Source_MQTT.ino` | Support de `TopicP_T` : cache distinct `PwMQTT_T`/`PvaMQTT_T`/`PfMQTT_T`. `UpdatePmqtt()` choisit la source de vérité selon `canal_lecture_courant`. Écritures via pointeurs canal. |
| `Source_NotDef.ino`, `Source_EnphaseEnvoy.ino`, `Source_SmartG.ino`, `Source_HomeWizard.ino`, `Source_Linky.ino`, `Source_Externe.ino` | **Strictement inchangés** : restent utilisables uniquement comme `Source` (exclus du dropdown `Source_T`). |
| `EnvoiMQTT.ino` | Souscription à `TopicP_T` si `Source_T == "Pmqtt"`. Callback dispatche `TopicP_T` vers le cache T. Discovery + payload des variables `_T` conditionnés sur `Source_T != "NotDef"` (en plus des sources multi-mesures). Champ `Source_T` ajouté au payload. |
| `PagePara.h` | Label "Source" devient "Source Maison (M)". Ajout d'un dropdown "Source Triac (T)" toujours visible (option "Aucune" par défaut). Champ `TopicP_T` affiché quand `Source_T == "Pmqtt"`. Avertissement si `Source_T == Source`. |
| `JS_Para.h` | Lecture/écriture des nouveaux champs, affichage conditionnel, validation `Source_T != Source` (sauf pour les sources multi-mesures). |

---

## Compatibilité ascendante

Migration automatique au boot :

```
parametres.json sans Source_T :
  - Source ∈ {"UxIx2", "ShellyEm", "ShellyPro"} (sources multi-mesures, voir glossaire)
    → Source_T = Source        # préserve l'ancien comportement
                                # (la voie secondaire alimente la mesure Triac comme avant)
  - Source == toute autre valeur
    → Source_T = "NotDef"      # pas de mesure Triac, comportement identique à V17.19
```

Aucune intervention utilisateur nécessaire pour les installations existantes.

---

## Choix de design

### Pourquoi des pointeurs et pas une structure ?

L'indirection par pointeur permet une substitution **mécanique** dans les sources : `PuissanceS_M_inst = X` devient `*pPuissanceS_inst = X`. Une structure aurait imposé une syntaxe plus verbeuse (`canal->PuissanceS_inst`) et un changement plus invasif.

### Quelles sources sont disponibles comme `Source_T` et pourquoi ?

Le dropdown propose : `UxI`, `UxIx2`, `UxIx3`, `ShellyEm`, `ShellyPro`, `Pmqtt` (et `NotDef` = pas de mesure Triac). Ce sont les sources qui ont un sens physique comme mesure de Triac et qui ont été effectivement refactorisées.

**Sources exclues du dropdown `Source_T`** :
- **Linky** : écrit directement les variables d'affichage sans passer par `filtre_puissance()`. Refacto possible mais invasive pour un cas d'usage théorique (Linky est un compteur Maison).
- **Enphase, SmartG, HomeW** : compteurs Maison — pas de sens physique comme mesure de Triac. Code laissé strictement inchangé.
- **NotDef** : source de simulation, sans mesure réelle.
- **Ext** : chaînage d'ESP32 hors scope.

Ces sources restent pleinement utilisables comme `Source` (mesure Maison).

### Limitation pour UxIx3 utilisé comme `Source_T`

UxIx3 (JSY-MK-333 triphasé) est utilisable comme `Source_T` pour mesurer un Triac mono ou triphasé. Les variables somme (`PuissanceS_T`, `Energie_T_*`, etc.) sont alimentées correctement via pointeurs.

**En revanche**, les variables par phase (`Tension_M1/M2/M3`, `Intensite_M1/M2/M3`, `PW_M1/M2/M3`) conservent leur préfixe `_M` historique. Quand UxIx3 est utilisée comme `Source_T`, ces variables reflètent en réalité les phases du Triac — l'étiquetage est trompeur mais l'information est correcte. La page "Données brutes" affiche simplement "Phase 1/2/3" sans préfixe, donc sans ambiguïté pratique.

### Pourquoi `filtre_puissance()` est inchangée ?

Choix volontaire : `filtre_puissance()` filtre toujours les variables Maison et Triac, comme dans V17.19. Conséquence quand `Source_T` est active : double application du filtre par cycle (une par chaque source). Effet marginal, documenté en section "Différences résiduelles". Aucun risque de régression pour les utilisateurs sans `Source_T`.

---

## Cas d'usage MQTT (Pmqtt comme Source_T)

Pour utiliser MQTT comme `Source_T` :

1. Configurer un capteur tiers qui publie la puissance du Triac sur un topic MQTT (par exemple `solar/triac/power`).
2. Dans l'interface : *Source Triac (T)* = "MQTT (topic distinct)".
3. Renseigner *MQTT Topic Puissance Triac* avec le nom du topic.
4. Le routeur souscrit automatiquement à ce topic et alimente les variables `_T`.

La configuration MQTT existante (`TopicP`) reste inchangée : `TopicP_T` est un champ supplémentaire **indépendant**. Un utilisateur qui utilisait déjà Pmqtt comme `Source` n'a rien à modifier après mise à jour.

---

## Tests d'intégration recommandés (à exécuter sur matériel)

1. **Non-régression source unique** : `Source_T = "NotDef"` avec chaque source possible. Vérifier que le routage et MQTT sont identiques à V17.19.
2. **Migration** : booter avec un `parametres.json` V17.19 contenant `Source = "UxIx2"`. Vérifier que `Source_T = "UxIx2"` apparaît automatiquement après reboot.
3. **Deux sources distinctes** : `Source = "ShellyEm"`, `Source_T = "UxI"`. Vérifier que les variables `_M` viennent du Shelly et `_T` du capteur UxI sur la page Brute.
4. **Pmqtt double** : `Source = "Pmqtt"` (topic `maison/power`), `Source_T = "Pmqtt"` (topic `triac/power`). Vérifier souscription aux deux topics et alimentation des deux mesures.
5. **`Source_T == Source` non-dual** : configurer `Source = "UxI"`, `Source_T = "UxI"`. Vérifier que l'avertissement UI apparaît et que la seconde lecture est court-circuitée par le firmware.
6. **Auto-discovery Home Assistant** : vérifier que les entités `*_T` apparaissent quand `Source_T != "NotDef"`.

---

## Différences résiduelles vs V17.19

Pour les utilisateurs **sans `Source_T` configurée** (`Source_T = "NotDef"`) : **aucune différence fonctionnelle**. Le filtre RC, le routage, l'affichage et MQTT sont byte-identiques à V17.19.

Pour les utilisateurs **avec `Source_T` active**, deux différences marginales :

1. **Léger double-filtrage en `LissageLong=true`**. Quand `filtre_puissance()` est appelée deux fois par cycle (une par chaque source), les variables Maison sont filtrées deux fois. Effet : coefficient effectif du filtre RC `A_eff ≈ 0.51` au lieu de `0.3` durant les cycles concernés. La réactivité du PID est donc ~1.7× plus rapide quand `Source_T` est active avec lissage long. En `LissageLong=false` (A=1, B=0), aucun effet.

2. **Variables par phase de UxIx3 conservent leur préfixe `_M`** quand UxIx3 est utilisée comme `Source_T`. `Tension_M1`, `Intensite_M1`, `PW_M1`, etc. reflètent alors physiquement le Triac mais gardent leur nom historique. La page "Données brutes" affiche juste "Phase 1/2/3" donc sans ambiguïté à l'écran.

---

## Checklist mainteneur

- [ ] Tester sur matériel réel avec une combinaison Shelly + UxI ou Linky + UxIx2
- [ ] Vérifier la rétrocompatibilité avec un `parametres.json` V17.19 existant
- [ ] Vérifier l'auto-discovery Home Assistant
- [ ] Valider la traduction des libellés si besoin

---

## Glossaire des termes utilisés

*Cette section liste les termes employés dans la PR, en distinguant ce qui vient du code existant de ce qui est introduit ici. Présenté à toutes fins utiles ; si certains termes méritent un jour d'être harmonisés dans la doc du projet, le mainteneur pourra puiser dedans.*

**Termes du projet (rappel)** :
- **Maison** : entrée réseau du capteur principal. Alimente les variables `_M_*`. Pilote le routage.
- **Triac** : sortie pilotée par le routeur. Alimente les variables `_T_*`. Affichage et MQTT seulement.
- **Source** : option de configuration du firmware désignant la méthode de mesure (chaîne `"UxI"`, `"UxIx2"`, `"ShellyEm"`, ...). À distinguer du capteur physique.
- **Capteur** : équipement matériel qui réalise la mesure (clamp UxI, module JSY-MK-194T, Shelly Em, Linky, ...).
- **Voie** : entrée physique d'un capteur ayant plusieurs entrées (voie 1 / voie 2 du JSY-MK-194T, voies 0/1/2 d'un Shelly Em monophasé).
- **Non définie** (valeur `"NotDef"` en interne) : valeur sentinelle indiquant l'absence de source configurée.

**Ajouté par cette PR** :
- **`Source_T`** : option de configuration désignant la source qui fournit la mesure Triac. `"Non définie"` par défaut.
- **`TopicP_T`** : topic MQTT dédié à la source Triac quand `Source_T = "Pmqtt"`.
- **source multi-mesures** : source capable de fournir simultanément les mesures Maison et Triac en un seul appel matériel. Concerne `UxIx2` (toujours, via les 2 voies du JSY-MK-194T), `ShellyEm` et `ShellyProEm` quand ils sont en mode 2-voies.
- **mode 2-voies** (pour `ShellyEm` / `ShellyProEm`) : configuration matérielle où le capteur Shelly utilise deux de ses voies pour fournir les deux mesures (à distinguer du mode triphasé qui agrège les 3 phases en une seule mesure).

---
